### PR TITLE
備品の個数を0個に設定できるようにした

### DIFF
--- a/src/components/ItemPane.tsx
+++ b/src/components/ItemPane.tsx
@@ -158,6 +158,7 @@ const ItemPane: FC<Props> = (props) => {
                 label="個数"
                 onChange={onCountChange}
               >
+                <MenuItem value={0}>0</MenuItem>
                 <MenuItem value={1}>1</MenuItem>
                 <MenuItem value={2}>2</MenuItem>
                 <MenuItem value={3}>3</MenuItem>


### PR DESCRIPTION
close #8 

備品の個数を0個に設定できると特に途中から再開するときに便利なので、そうした。