### PR TITLE
fork先からstagingにデプロイできる設定を追加

### DIFF
--- a/.github/workflows/azure-static-web-apps-mango-sea-05aa22700.yml
+++ b/.github/workflows/azure-static-web-apps-mango-sea-05aa22700.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   build_and_deploy_job:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed' ) || ( github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'deploy_staging'))
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed' && github.event.pull_request.head.repo.fork == false ) || ( github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'deploy_staging'))
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:

--- a/.github/workflows/azure-static-web-apps-mango-sea-05aa22700.yml
+++ b/.github/workflows/azure-static-web-apps-mango-sea-05aa22700.yml
@@ -8,6 +8,8 @@ on:
     types: [opened, synchronize, reopened, closed]
     branches:
       - main
+  pull_request_target:
+    types: [labeled]
   workflow_dispatch:
 
 permissions:
@@ -16,7 +18,7 @@ permissions:
 
 jobs:
   build_and_deploy_job:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed' ) || ( github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'deploy_staging'))
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:


### PR DESCRIPTION
#7 でfork先からPRをもらっているが、現在の設定ではfork先からのPR内容をステージング環境にデプロイできなかった。
そのため、手動でデプロイできるように修正した（つもり）。

## 使い方

fork先からのPRに `deploy_staging` ラベルを付けるとステージング環境へのデプロイが走る。