### PR TITLE
計算したばかりのときは実行ボタンを白抜きに変更

### DIFF
--- a/src/components/ControlPane.tsx
+++ b/src/components/ControlPane.tsx
@@ -26,6 +26,7 @@ type Props = {
   openPanels: boolean[];
   isRunning: boolean;
   showProb: boolean[];
+  recommendToRun: boolean;
   onExecute: () => void;
   onToggleShowProb: (index: number) => void;
   onItemPresetApply: (preset: number) => void;
@@ -37,6 +38,7 @@ const ControlPane: FC<Props> = (props) => {
     openPanels,
     isRunning,
     showProb,
+    recommendToRun,
     onExecute,
     onToggleShowProb,
     onItemPresetApply,
@@ -46,6 +48,8 @@ const ControlPane: FC<Props> = (props) => {
   const handlepredefinedChoiceChange = (event: SelectChangeEvent) => {
     setPredefinedChoice(event.target.value);
   };
+
+  const runButtonStyle = recommendToRun ? 'contained' : 'outlined';
 
   return (
     <>
@@ -90,7 +94,7 @@ const ControlPane: FC<Props> = (props) => {
               onClick={onExecute}
               loading={isRunning}
               startIcon={<PlayArrowIcon />}
-              variant="contained"
+              variant={runButtonStyle}
               size="large"
             >
               <span>実行</span>

--- a/src/components/MainArea.tsx
+++ b/src/components/MainArea.tsx
@@ -76,6 +76,13 @@ const MainArea: FC = () => {
   const [openMap, setOpenMap] = useState(Array(45).fill(false) as boolean[]);
   const [workerResetCnt, setWorkerResetCnt] = useState(0);
 
+  // runUuid: 確率計算実行時に発行されたUUID
+  // opUuid: 確率計算実行時または直近の入力変更時に発行されたUUID
+  // runUuid === opUuidのとき、確率計算が実行されたばかりなので再度の確率計算を推奨しない
+  // runUuid !== opUuidのとき、入力が変更されているので確率計算を推奨する
+  const [runUuid, setRunUuid] = useState<string>(crypto.randomUUID());
+  const [opUuid, setOpUuid] = useState<string>(crypto.randomUUID());
+
   if (items.some((item) => item.placements.length > item.item.count)) {
     const newItems = items.map((item) => {
       return {
@@ -126,12 +133,14 @@ const MainArea: FC = () => {
     });
 
     setItems(newItems);
+    setOpUuid(crypto.randomUUID());
   };
 
   const onAddPlacedItem = (item: PlacedItem) => {
     const newItems = [...items];
     items[item.item.index - 1].placements.push(item);
     setItems(newItems);
+    setOpUuid(crypto.randomUUID());
   };
 
   const onModifyPlacedItem = (item: PlacedItem) => {
@@ -144,6 +153,7 @@ const MainArea: FC = () => {
     }
 
     setItems(newItems);
+    setOpUuid(crypto.randomUUID());
   };
 
   const onRemovePlacedItem = (item: PlacedItem) => {
@@ -154,6 +164,7 @@ const MainArea: FC = () => {
     ].placements.filter((it) => it.id !== item.id);
 
     setItems(newItems);
+    setOpUuid(crypto.randomUUID());
   };
 
   // 確率計算worker周り
@@ -173,6 +184,10 @@ const MainArea: FC = () => {
       }
 
       setIsRunning(false);
+
+      const uuid = crypto.randomUUID();
+      setRunUuid(uuid);
+      setOpUuid(uuid);
     };
 
     return () => {
@@ -203,6 +218,7 @@ const MainArea: FC = () => {
     const newOpenMap = [...openMap];
     newOpenMap[index] = !newOpenMap[index];
     setOpenMap(newOpenMap);
+    setOpUuid(crypto.randomUUID());
   };
 
   const onItemPresetApply = (preset: number) => {
@@ -217,6 +233,7 @@ const MainArea: FC = () => {
     );
     setProbs(null);
     setOpenMap(Array(45).fill(false));
+    setOpUuid(crypto.randomUUID());
     setIsRunning(false);
     setWorkerResetCnt((prev) => prev + 1);
   };
@@ -238,6 +255,7 @@ const MainArea: FC = () => {
           openPanels={openMap}
           isRunning={isRunning}
           showProb={showProbs}
+          recommendToRun={runUuid !== opUuid}
           onExecute={onExecute}
           onToggleShowProb={onToggleShowProb}
           onItemPresetApply={onItemPresetApply}


### PR DESCRIPTION
今まではいつ再計算すべきか分かりづらく、ユーザーが都度再計算せずにマスを開け続けてしまうおそれがあった。
確率計算直後は実行ボタンを白抜きに、その後入力を変化させた場合は青にすることで、いつ再計算すべきか分かりやすくした。