### PR TITLE
データが古い旨の注意書きを追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { Box, ThemeProvider, createTheme } from '@mui/material';
 import Header from './components/Header';
 import MainArea from './components/MainArea';
 import Note from './components/Note';
+import NotificationPanel from './components/NotificationPanel';
 
 const App: FC = () => {
   const theme = createTheme({
@@ -22,7 +23,8 @@ const App: FC = () => {
     <>
       <ThemeProvider theme={theme}>
         <Header />
-        <Box width={1200}>
+        <Box width={1200} mt={5}>
+          <NotificationPanel />
           <MainArea />
           <Note />
         </Box>

--- a/src/components/MainArea.tsx
+++ b/src/components/MainArea.tsx
@@ -239,7 +239,7 @@ const MainArea: FC = () => {
   };
 
   return (
-    <Box mt={5} mb={2}>
+    <Box mb={2}>
       <Box my={2}>
         <Board
           placedItems={items.map((item) => item.placements).flat()}

--- a/src/components/NotificationPanel.tsx
+++ b/src/components/NotificationPanel.tsx
@@ -1,0 +1,19 @@
+import { type FC } from 'react';
+import { Alert, Box, Paper } from '@mui/material';
+
+const NotificationPanel: FC = () => {
+  return (
+    <>
+      <Paper>
+        <Box p={2} textAlign="start">
+          <Alert severity="warning">
+            こちらのツールは2024/4/11開始の総決算イベントのデータに基づいています。
+            2024/6/5開始の総決算イベントには未対応ですので、恐れ入りますがデータが出揃うまでお待ちください。
+          </Alert>
+        </Box>
+      </Paper>
+    </>
+  );
+};
+
+export default NotificationPanel;


### PR DESCRIPTION
2024/6/5から再度在庫管理イベントが開始されるので、以下の注意書きを追加した。

> こちらのツールは2024/4/11開始の総決算イベントのデータに基づいています。 2024/6/5開始の総決算イベントには未対応ですので、恐れ入りますがデータが出揃うまでお待ちください。