### PR TITLE
備品を追加したときに確定したマスを自動で開くようにする

### DIFF
--- a/src/components/MainArea.tsx
+++ b/src/components/MainArea.tsx
@@ -153,15 +153,15 @@ const MainArea: FC = () => {
     const newItems = [...items];
     newItems[item.item.index - 1].placements.push(item);
     setItems(newItems);
-    
+
     // アイテムがある場所のマス目を自動で開ける
     const newOpenMap = [...openMap];
     for (let i = item.row; i < item.row + getRotatedHeight(item); i++) {
       for (let j = item.col; j < item.col + getRotatedWidth(item); j++) {
-        newOpenMap[i * 9 + j] = true;
+        newOpenMap[(i - 1) * 9 + (j - 1)] = true;
       }
     }
-    
+
     setOpenMap(newOpenMap);
     setOpUuid(crypto.randomUUID());
   };

--- a/src/components/MainArea.tsx
+++ b/src/components/MainArea.tsx
@@ -151,8 +151,18 @@ const MainArea: FC = () => {
 
   const onAddPlacedItem = (item: PlacedItem) => {
     const newItems = [...items];
-    items[item.item.index - 1].placements.push(item);
+    newItems[item.item.index - 1].placements.push(item);
     setItems(newItems);
+    
+    // アイテムがある場所のマス目を自動で開ける
+    const newOpenMap = [...openMap];
+    for (let i = item.row; i < item.row + getRotatedHeight(item); i++) {
+      for (let j = item.col; j < item.col + getRotatedWidth(item); j++) {
+        newOpenMap[i * 9 + j] = true;
+      }
+    }
+    
+    setOpenMap(newOpenMap);
     setOpUuid(crypto.randomUUID());
   };
 


### PR DESCRIPTION
備品の位置が判明したあとは確定したマスを開けて再計算したいことがほとんどかなぁと思ったので、備品を追加したときに確定したマスを自動で開くようにしてみました

- 備品を移動・削除したときはマスは更新されません
  - 備品配置 UI が新しくなってから配置をミスることはほぼなくなったと思うので、万一置き間違えたら開いてしまったマスは手動で閉じてもらうということにしました

ついでに多分 `newItems` を使うべき部分を `items` から変更しておきました

P.S.
commit message typo してる… suimasenn…
> `open cells on a placed cells automatically` → `open cells on a placed item automatically`