### PR TITLE
最大確率マスの強調表示を計算実行時以外更新しないようにした

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -11,14 +11,18 @@ import './Board.css';
 export interface Props {
   placedItems: PlacedItem[];
   probs: number[][] | null;
+  isMaxProbs: boolean[][] | null;
   openMap: boolean[];
   showProb: boolean[];
   onToggleOpen: (idx: number) => void;
 }
 
 const Board: FC<Props> = (props) => {
-  const { placedItems, probs, openMap, showProb, onToggleOpen } = props;
+  const { placedItems, probs, isMaxProbs, openMap, showProb, onToggleOpen } =
+    props;
 
+  // 注目しているアイテムの組合せフラグ
+  // 備品1, 2, 3に対して、それぞれ確率計算時に考慮するか（2^3通り）を表す
   let probFlag = 0;
 
   for (let i = 0; i < showProb.length; i++) {
@@ -32,17 +36,13 @@ const Board: FC<Props> = (props) => {
   }
 
   const targetProbs = probs?.[probFlag] ?? Array<number>(45).fill(0.0);
+  const targetIsMaxProbs =
+    isMaxProbs?.[probFlag] ?? Array<boolean>(45).fill(false);
 
-  // 小数点第一位まで見て、最大値に一致するものにフラグを付けたい
-  const roundProb = (prob: number) => Math.round(prob * 1000) / 1000;
-  let roundedMax = 0;
+  // 最大確率を探す
   let maxProb = -Infinity;
 
   for (let i = 0; i < targetProbs.length; i++) {
-    const rounded = roundProb(targetProbs[i]);
-    if (!openMap[i] && rounded > roundedMax) {
-      roundedMax = rounded;
-    }
     if (!openMap[i] && targetProbs[i] !== 0 && targetProbs[i] > maxProb) {
       maxProb = targetProbs[i];
     }
@@ -54,7 +54,7 @@ const Board: FC<Props> = (props) => {
     open: openMap[index],
     prob,
     probFlag,
-    isBest: !openMap[index] && prob > 0 && roundProb(prob) === roundedMax,
+    isBest: !openMap[index] && targetIsMaxProbs[index],
     maxProb,
   }));
 


### PR DESCRIPTION
以下のpostにて、「アイテムを配置した際に強調表示マスの位置も自動で変わってしまう（が、再計算していないため表示される確率は古いまま）ため、うっかり確率最大でないマスを開けてしまう」というフィードバックを頂いた。
確かに混乱の元であるため、計算実行時以外は最大確率マスの強調表示を更新しないように変更した。
https://x.com/foobarapple/status/1843665734129619283