### PR TITLE
2024/12/24開始イベントへの対応 part1

### DIFF
--- a/src/components/MainArea.tsx
+++ b/src/components/MainArea.tsx
@@ -58,32 +58,32 @@ const predefinedItems: ItemSet[][] = [
     { item: { ...characterToothbrush, index: 2 }, count: 5 },
     { item: { ...purpleScarf, index: 3 }, count: 2 },
   ],
-  [  // FIXME: below counts are not updated
+  [
     { item: { ...boardGame, index: 1 }, count: 1 },
     { item: { ...bodyPillow, index: 2 }, count: 2 },
-    { item: { ...characterToothbrush, index: 3 }, count: 3 },
+    { item: { ...characterToothbrush, index: 3 }, count: 5 },
   ],
   [
     { item: { ...characterPillow, index: 1 }, count: 1 },
-    { item: { ...hairband, index: 2 }, count: 3 },
-    { item: { ...purpleScarf, index: 3 }, count: 2 },
+    { item: { ...hairband, index: 2 }, count: 4 },
+    { item: { ...purpleScarf, index: 3 }, count: 3 },
   ],
   [
-    { item: { ...slippers, index: 1 }, count: 1 },
+    { item: { ...slippers, index: 1 }, count: 2 },
     { item: { ...characterToothbrush, index: 2 }, count: 5 },
     { item: { ...purpleScarf, index: 3 }, count: 2 },
   ],
   [
     { item: { ...boardGame, index: 1 }, count: 1 },
     { item: { ...bodyPillow, index: 2 }, count: 2 },
-    { item: { ...characterToothbrush, index: 3 }, count: 3 },
+    { item: { ...characterToothbrush, index: 3 }, count: 5 },
   ],
   [
     { item: { ...characterPillow, index: 1 }, count: 1 },
-    { item: { ...hairband, index: 2 }, count: 3 },
-    { item: { ...purpleScarf, index: 3 }, count: 2 },
+    { item: { ...hairband, index: 2 }, count: 4 },
+    { item: { ...purpleScarf, index: 3 }, count: 3 },
   ],
-  [
+  [  // FIXME: below counts are not updated
     { item: { ...boardGame, index: 1 }, count: 2 },
     { item: { ...characterToothbrush, index: 2 }, count: 3 },
     { item: { ...purpleScarf, index: 3 }, count: 6 },

--- a/src/components/MainArea.tsx
+++ b/src/components/MainArea.tsx
@@ -33,6 +33,7 @@ const ambrella = { width: 1, height: 4 } as const;
 */
 
 // 五塵来降のアイテム
+/*
 const longxutang = { width: 3, height: 2 } as const; // 龍のひげ飴
 const ludagun = { width: 3, height: 1 } as const; // ローダーグン
 const yuebing = { width: 2, height: 1 } as const; // 月餅
@@ -40,42 +41,52 @@ const mahua = { width: 4, height: 2 } as const; // 麻花
 const xingrenDoufu = { width: 2, height: 2 } as const; // 杏仁豆腐
 const banji = { width: 3, height: 3 } as const; // 班戟（パンケーキ）
 const tanghulu = { width: 1, height: 4 } as const; // 糖葫蘆
+*/
+
+// 秘密のミッドナイトパーティーのアイテム
+const slippers = { width: 3, height: 2 } as const; // スリッパ
+const characterToothbrush = { width: 3, height: 1 } as const; // キャラもの歯ブラシ
+const purpleScarf = { width: 2, height: 1 } as const; // 紫のマフラー
+const boardGame = { width: 4, height: 2 } as const; // ボードゲーム「KIVOPOLY」
+const hairband = { width: 2, height: 2 } as const; // ヘアバンド
+const characterPillow = { width: 3, height: 3 } as const; // キャラものクッション
+const bodyPillow = { width: 1, height: 4 } as const; // 抱き枕
 
 const predefinedItems: ItemSet[][] = [
   [
-    { item: { ...longxutang, index: 1 }, count: 1 },
-    { item: { ...ludagun, index: 2 }, count: 5 },
-    { item: { ...yuebing, index: 3 }, count: 2 },
+    { item: { ...slippers, index: 1 }, count: 2 },
+    { item: { ...characterToothbrush, index: 2 }, count: 5 },
+    { item: { ...purpleScarf, index: 3 }, count: 2 },
+  ],
+  [  // FIXME: below counts are not updated
+    { item: { ...boardGame, index: 1 }, count: 1 },
+    { item: { ...bodyPillow, index: 2 }, count: 2 },
+    { item: { ...characterToothbrush, index: 3 }, count: 3 },
   ],
   [
-    { item: { ...mahua, index: 1 }, count: 1 },
-    { item: { ...xingrenDoufu, index: 2 }, count: 2 },
-    { item: { ...ludagun, index: 3 }, count: 3 },
+    { item: { ...characterPillow, index: 1 }, count: 1 },
+    { item: { ...hairband, index: 2 }, count: 3 },
+    { item: { ...purpleScarf, index: 3 }, count: 2 },
   ],
   [
-    { item: { ...banji, index: 1 }, count: 1 },
-    { item: { ...tanghulu, index: 2 }, count: 3 },
-    { item: { ...yuebing, index: 3 }, count: 2 },
+    { item: { ...slippers, index: 1 }, count: 1 },
+    { item: { ...characterToothbrush, index: 2 }, count: 5 },
+    { item: { ...purpleScarf, index: 3 }, count: 2 },
   ],
   [
-    { item: { ...longxutang, index: 1 }, count: 1 },
-    { item: { ...ludagun, index: 2 }, count: 5 },
-    { item: { ...yuebing, index: 3 }, count: 2 },
+    { item: { ...boardGame, index: 1 }, count: 1 },
+    { item: { ...bodyPillow, index: 2 }, count: 2 },
+    { item: { ...characterToothbrush, index: 3 }, count: 3 },
   ],
   [
-    { item: { ...mahua, index: 1 }, count: 1 },
-    { item: { ...xingrenDoufu, index: 2 }, count: 2 },
-    { item: { ...ludagun, index: 3 }, count: 3 },
+    { item: { ...characterPillow, index: 1 }, count: 1 },
+    { item: { ...hairband, index: 2 }, count: 3 },
+    { item: { ...purpleScarf, index: 3 }, count: 2 },
   ],
   [
-    { item: { ...banji, index: 1 }, count: 1 },
-    { item: { ...tanghulu, index: 2 }, count: 3 },
-    { item: { ...yuebing, index: 3 }, count: 2 },
-  ],
-  [
-    { item: { ...xingrenDoufu, index: 1 }, count: 2 },
-    { item: { ...ludagun, index: 2 }, count: 3 },
-    { item: { ...yuebing, index: 3 }, count: 6 },
+    { item: { ...boardGame, index: 1 }, count: 2 },
+    { item: { ...characterToothbrush, index: 2 }, count: 3 },
+    { item: { ...purpleScarf, index: 3 }, count: 6 },
   ],
 ] as const;
 

--- a/src/components/NotificationPanel.tsx
+++ b/src/components/NotificationPanel.tsx
@@ -6,9 +6,10 @@ const NotificationPanel: FC = () => {
     <>
       <Paper>
         <Box p={2} textAlign="start">
-          <Alert severity="success">
-            2024/9/25開始の山海経イベントへの対応を完了しました。
-            お気付きの点がございましたら
+          <Alert severity="warning">
+            現在、2024/12/24開始のミレニアムイベントの対応を進めています。
+            1周目の備品の種類・数量については最新版への更新が完了しておりますが、2周目以降の備品の数量については不明なため仮の値を設定しています。
+            2周目以降の備品数量をご存じの方は
             <a
               href="https://github.com/terry-u16/schale-inventory-management/issues"
               target="_blank"
@@ -17,6 +18,7 @@ const NotificationPanel: FC = () => {
               githubのissue
             </a>
             にてご報告頂けますと幸いです。
+            ご不便をおかけしますが、どうぞよろしくお願いいたします。
           </Alert>
         </Box>
       </Paper>

--- a/src/components/NotificationPanel.tsx
+++ b/src/components/NotificationPanel.tsx
@@ -8,8 +8,8 @@ const NotificationPanel: FC = () => {
         <Box p={2} textAlign="start">
           <Alert severity="warning">
             現在、2024/12/24開始のミレニアムイベントの対応を進めています。
-            1周目の備品の種類・数量については最新版への更新が完了しておりますが、2周目以降の備品の数量については不明なため仮の値を設定しています。
-            2周目以降の備品数量をご存じの方は
+            6周目までの備品の種類・数量については最新版への更新が完了しておりますが、7周目以降の備品の数量については不明なため仮の値を設定しています。
+            7周目以降の備品数量をご存じの方は
             <a
               href="https://github.com/terry-u16/schale-inventory-management/issues"
               target="_blank"


### PR DESCRIPTION
12/24のイベント開始に伴い、以下の対応を行った。

- 備品の種類の更新
- 備品の数量の更新（確認できているのは6周目のみ。7周目以降は仮の値を入力している）
- ページ上部に表示するメッセージの更新