### PR TITLE
2024/12ミレニアムイベントの7周目備品数量を更新

### DIFF
--- a/src/components/MainArea.tsx
+++ b/src/components/MainArea.tsx
@@ -83,7 +83,7 @@ const predefinedItems: ItemSet[][] = [
     { item: { ...hairband, index: 2 }, count: 4 },
     { item: { ...purpleScarf, index: 3 }, count: 3 },
   ],
-  [  // FIXME: below counts are not updated
+  [
     { item: { ...boardGame, index: 1 }, count: 2 },
     { item: { ...characterToothbrush, index: 2 }, count: 3 },
     { item: { ...purpleScarf, index: 3 }, count: 6 },

--- a/src/components/NotificationPanel.tsx
+++ b/src/components/NotificationPanel.tsx
@@ -6,10 +6,9 @@ const NotificationPanel: FC = () => {
     <>
       <Paper>
         <Box p={2} textAlign="start">
-          <Alert severity="warning">
-            現在、2024/12/24開始のミレニアムイベントの対応を進めています。
-            6周目までの備品の種類・数量については最新版への更新が完了しておりますが、7周目以降の備品の数量については不明なため仮の値を設定しています。
-            7周目以降の備品数量をご存じの方は
+          <Alert severity="success">
+            2024/12/24開始のミレニアムイベントの対応を完了しました。
+            お気付きの点がございましたら
             <a
               href="https://github.com/terry-u16/schale-inventory-management/issues"
               target="_blank"
@@ -18,7 +17,6 @@ const NotificationPanel: FC = () => {
               githubのissue
             </a>
             にてご報告頂けますと幸いです。
-            ご不便をおかけしますが、どうぞよろしくお願いいたします。
           </Alert>
         </Box>
       </Paper>


### PR DESCRIPTION
close #48 

7周目以降の備品数量を更新した。
wikiを見る限りたまたま前回と同じ数量で合っていたらしい？