### PR TITLE
2025/3/13開始イベントへの対応 part1

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@eslint/js": "^9.17.0",
     "@types/eslint": "~8.56.12",
     "@types/eslint-config-prettier": "~6.11.3",
+    "@types/eslint-plugin-jsx-a11y": "~6.10.0",
     "@types/eslint__eslintrc": "~2.1.2",
     "@types/eslint__js": "~8.42.3",
     "@types/lint-staged": "~13.3.0",

--- a/src/components/MainArea.tsx
+++ b/src/components/MainArea.tsx
@@ -22,7 +22,6 @@ const clampPosition = (value: number, size: number, boardSize: number) => {
 };
 
 // 在庫管理のアイテム
-/*
 const shoppingBag = { width: 3, height: 2 } as const;
 const receipt = { width: 1, height: 3 } as const;
 const fountainPen = { width: 2, height: 1 } as const;
@@ -30,7 +29,6 @@ const toyBox = { width: 4, height: 2 } as const;
 const potatoChips = { width: 2, height: 2 } as const;
 const gameMagazine = { width: 3, height: 3 } as const;
 const ambrella = { width: 1, height: 4 } as const;
-*/
 
 // 五塵来降のアイテム
 /*
@@ -44,6 +42,7 @@ const tanghulu = { width: 1, height: 4 } as const; // 糖葫蘆
 */
 
 // 秘密のミッドナイトパーティーのアイテム
+/*
 const slippers = { width: 3, height: 2 } as const; // スリッパ
 const characterToothbrush = { width: 3, height: 1 } as const; // キャラもの歯ブラシ
 const purpleScarf = { width: 2, height: 1 } as const; // 紫のマフラー
@@ -51,42 +50,43 @@ const boardGame = { width: 4, height: 2 } as const; // ボードゲーム「KIVO
 const hairband = { width: 2, height: 2 } as const; // ヘアバンド
 const characterPillow = { width: 3, height: 3 } as const; // キャラものクッション
 const bodyPillow = { width: 1, height: 4 } as const; // 抱き枕
+*/
 
 const predefinedItems: ItemSet[][] = [
   [
-    { item: { ...slippers, index: 1 }, count: 2 },
-    { item: { ...characterToothbrush, index: 2 }, count: 5 },
-    { item: { ...purpleScarf, index: 3 }, count: 2 },
+    { item: { ...potatoChips, index: 1 }, count: 3 },
+    { item: { ...shoppingBag, index: 2 }, count: 2 },
+    { item: { ...toyBox, index: 3 }, count: 1 },
   ],
   [
-    { item: { ...boardGame, index: 1 }, count: 1 },
-    { item: { ...bodyPillow, index: 2 }, count: 2 },
-    { item: { ...characterToothbrush, index: 3 }, count: 5 },
+    { item: { ...receipt, index: 1 }, count: 2 },
+    { item: { ...shoppingBag, index: 2 }, count: 2 },
+    { item: { ...gameMagazine, index: 3 }, count: 1 },
   ],
   [
-    { item: { ...characterPillow, index: 1 }, count: 1 },
-    { item: { ...hairband, index: 2 }, count: 4 },
-    { item: { ...purpleScarf, index: 3 }, count: 3 },
+    { item: { ...fountainPen, index: 1 }, count: 5 },
+    { item: { ...receipt, index: 2 }, count: 3 },
+    { item: { ...ambrella, index: 3 }, count: 2 },
   ],
   [
-    { item: { ...slippers, index: 1 }, count: 2 },
-    { item: { ...characterToothbrush, index: 2 }, count: 5 },
-    { item: { ...purpleScarf, index: 3 }, count: 2 },
+    { item: { ...potatoChips, index: 1 }, count: 3 },
+    { item: { ...shoppingBag, index: 2 }, count: 2 },
+    { item: { ...toyBox, index: 3 }, count: 1 },
   ],
   [
-    { item: { ...boardGame, index: 1 }, count: 1 },
-    { item: { ...bodyPillow, index: 2 }, count: 2 },
-    { item: { ...characterToothbrush, index: 3 }, count: 5 },
+    { item: { ...receipt, index: 1 }, count: 2 },
+    { item: { ...shoppingBag, index: 2 }, count: 2 },
+    { item: { ...gameMagazine, index: 3 }, count: 1 },
   ],
   [
-    { item: { ...characterPillow, index: 1 }, count: 1 },
-    { item: { ...hairband, index: 2 }, count: 4 },
-    { item: { ...purpleScarf, index: 3 }, count: 3 },
+    { item: { ...fountainPen, index: 1 }, count: 5 },
+    { item: { ...receipt, index: 2 }, count: 3 },
+    { item: { ...ambrella, index: 3 }, count: 2 },
   ],
   [
-    { item: { ...boardGame, index: 1 }, count: 2 },
-    { item: { ...characterToothbrush, index: 2 }, count: 3 },
-    { item: { ...purpleScarf, index: 3 }, count: 6 },
+    { item: { ...shoppingBag, index: 1 }, count: 2 },
+    { item: { ...toyBox, index: 2 }, count: 1 },
+    { item: { ...gameMagazine, index: 3 }, count: 1 },
   ],
 ] as const;
 

--- a/src/components/NotificationPanel.tsx
+++ b/src/components/NotificationPanel.tsx
@@ -6,9 +6,10 @@ const NotificationPanel: FC = () => {
     <>
       <Paper>
         <Box p={2} textAlign="start">
-          <Alert severity="success">
-            2024/12/24開始のミレニアムイベントの対応を完了しました。
-            お気付きの点がございましたら
+          <Alert severity="warning">
+            現在、2025/3/12開始の総決算イベントの対応を進めています。
+            1周目の備品の種類・数量については最新版への更新が完了しておりますが、2周目以降の備品の数量については不明なため仮の値を設定しています。
+            また、4～6周目の備品の数量については1～3周目の数量と同じであると仮定しているため、念のため使用前に実際の数量と異なっていないかご確認ください。
             <a
               href="https://github.com/terry-u16/schale-inventory-management/issues"
               target="_blank"
@@ -17,6 +18,7 @@ const NotificationPanel: FC = () => {
               githubのissue
             </a>
             にてご報告頂けますと幸いです。
+            ご不便をおかけしますが、どうぞよろしくお願いいたします。
           </Alert>
         </Box>
       </Paper>


### PR DESCRIPTION
3/13のイベント開始に伴い、以下の対応を行った。
#58 も参照のこと。

- 備品の種類の更新
- 備品の数量の更新（確認できているのは1周目のみ。2周目以降は仮の値を入力している）
- 注意書きの更新