### PR TITLE
2025/3/13開始イベントへの対応 part3

### DIFF
--- a/src/components/NotificationPanel.tsx
+++ b/src/components/NotificationPanel.tsx
@@ -6,10 +6,9 @@ const NotificationPanel: FC = () => {
     <>
       <Paper>
         <Box p={2} textAlign="start">
-          <Alert severity="warning">
-            現在、2025/3/12開始の総決算イベントの対応を進めています。
-            1～6周目の備品の種類・数量については最新版への更新が完了しておりますが、7周目以降の備品の数量については不明なため仮の値を設定しています。
-            また、4～6周目の備品の数量については1～3周目の数量と同じであると仮定しているため、念のため使用前に実際の数量と異なっていないかご確認ください。
+          <Alert severity="success">
+            2025/3/12開始の総決算イベントの対応を完了しました。
+            お気付きの点がございましたら
             <a
               href="https://github.com/terry-u16/schale-inventory-management/issues"
               target="_blank"
@@ -18,7 +17,6 @@ const NotificationPanel: FC = () => {
               githubのissue
             </a>
             にてご報告頂けますと幸いです。
-            ご不便をおかけしますが、どうぞよろしくお願いいたします。
           </Alert>
         </Box>
       </Paper>


### PR DESCRIPTION
3/13のイベント開始に伴い、以下の対応を行った。
#58 も参照のこと。

- 7周目の備品の数量の更新（変更がないことを確認）
- 注意書きの更新