### PR TITLE
プリセット適用時の確認ダイアログ削除・プリセット適用通知追加

### DIFF
--- a/public/locales/en/MainArea.json
+++ b/public/locales/en/MainArea.json
@@ -1,4 +1,4 @@
 {
   "reset_confirm": "Your current input will be reset. Are you sure?",
-  "item_preset_applied_toast": "Applied item preset for {{presetLabel}}"
+  "item_preset_applied_toast": "Applied supply preset for {{presetLabel}}"
 }

--- a/public/locales/en/MainArea.json
+++ b/public/locales/en/MainArea.json
@@ -1,4 +1,5 @@
 {
   "item_preset_apply_confirm": "Your current input will be reset. Are you sure?",
-  "reset_confirm": "Your current input will be reset. Are you sure?"
+  "reset_confirm": "Your current input will be reset. Are you sure?",
+  "item_preset_applied_toast": "Applied item preset for {{presetLabel}}"
 }

--- a/public/locales/en/MainArea.json
+++ b/public/locales/en/MainArea.json
@@ -1,5 +1,4 @@
 {
-  "item_preset_apply_confirm": "Your current input will be reset. Are you sure?",
   "reset_confirm": "Your current input will be reset. Are you sure?",
   "item_preset_applied_toast": "Applied item preset for {{presetLabel}}"
 }

--- a/public/locales/ja/MainArea.json
+++ b/public/locales/ja/MainArea.json
@@ -1,4 +1,4 @@
 {
   "reset_confirm": "現在の入力内容はリセットされます。よろしいですか？",
-  "item_preset_applied_toast": "{{presetLabel}}のアイテムプリセットを適用しました"
+  "item_preset_applied_toast": "{{presetLabel}}の備品プリセットを適用しました"
 }

--- a/public/locales/ja/MainArea.json
+++ b/public/locales/ja/MainArea.json
@@ -1,5 +1,4 @@
 {
-  "item_preset_apply_confirm": "現在の入力内容はリセットされます。よろしいですか？",
   "reset_confirm": "現在の入力内容はリセットされます。よろしいですか？",
   "item_preset_applied_toast": "{{presetLabel}}のアイテムプリセットを適用しました"
 }

--- a/public/locales/ja/MainArea.json
+++ b/public/locales/ja/MainArea.json
@@ -1,4 +1,5 @@
 {
   "item_preset_apply_confirm": "現在の入力内容はリセットされます。よろしいですか？",
-  "reset_confirm": "現在の入力内容はリセットされます。よろしいですか？"
+  "reset_confirm": "現在の入力内容はリセットされます。よろしいですか？",
+  "item_preset_applied_toast": "{{presetLabel}}のアイテムプリセットを適用しました"
 }

--- a/public/locales/ko/MainArea.json
+++ b/public/locales/ko/MainArea.json
@@ -1,5 +1,4 @@
 {
-  "item_preset_apply_confirm": "현재 재고가 재설정됩니다. 적용하시겠습니까?",
   "reset_confirm": "현재 재고가 재설정됩니다. 적용하시겠습니까?",
   "item_preset_applied_toast": "{{presetLabel}} 아이템 프리셋을 적용했습니다"
 }

--- a/public/locales/ko/MainArea.json
+++ b/public/locales/ko/MainArea.json
@@ -1,4 +1,4 @@
 {
   "reset_confirm": "현재 재고가 재설정됩니다. 적용하시겠습니까?",
-  "item_preset_applied_toast": "{{presetLabel}} 아이템 프리셋을 적용했습니다"
+  "item_preset_applied_toast": "{{presetLabel}} 비품 프리셋을 적용했습니다"
 }

--- a/public/locales/ko/MainArea.json
+++ b/public/locales/ko/MainArea.json
@@ -1,4 +1,5 @@
 {
   "item_preset_apply_confirm": "현재 재고가 재설정됩니다. 적용하시겠습니까?",
-  "reset_confirm": "현재 재고가 재설정됩니다. 적용하시겠습니까?"
+  "reset_confirm": "현재 재고가 재설정됩니다. 적용하시겠습니까?",
+  "item_preset_applied_toast": "{{presetLabel}} 아이템 프리셋을 적용했습니다"
 }

--- a/public/locales/zh-CN/MainArea.json
+++ b/public/locales/zh-CN/MainArea.json
@@ -1,4 +1,5 @@
 {
   "item_preset_apply_confirm": "板面的所有内容将全部丢失。确定要重置吗？",
-  "reset_confirm": "板面的所有内容将全部丢失。确定要重置吗？"
+  "reset_confirm": "板面的所有内容将全部丢失。确定要重置吗？",
+  "item_preset_applied_toast": "已应用 {{presetLabel}} 的道具预设"
 }

--- a/public/locales/zh-CN/MainArea.json
+++ b/public/locales/zh-CN/MainArea.json
@@ -1,5 +1,4 @@
 {
-  "item_preset_apply_confirm": "板面的所有内容将全部丢失。确定要重置吗？",
   "reset_confirm": "板面的所有内容将全部丢失。确定要重置吗？",
   "item_preset_applied_toast": "已应用 {{presetLabel}} 的道具预设"
 }

--- a/src/components/MainArea.tsx
+++ b/src/components/MainArea.tsx
@@ -357,10 +357,6 @@ const MainArea: FC = () => {
   };
 
   const onItemPresetApply = (preset: number) => {
-    if (!window.confirm(t('item_preset_apply_confirm'))) {
-      return;
-    }
-
     setItems(
       predefinedItems[preset].map(
         (itemSet) => new ItemAndPlacement(itemSet, []),

--- a/src/components/MainArea.tsx
+++ b/src/components/MainArea.tsx
@@ -161,9 +161,10 @@ const MainArea: FC = () => {
   const [isMaxProbs, setIsMaxProbs] = useState<boolean[][] | null>(null);
   const [showProbs, setShowProbs] = useState([true, true, true]);
   const [isRunning, setIsRunning] = useState(false);
-  const [presetAppliedToast, setPresetAppliedToast] = useState<string | null>(
-    null,
-  );
+  const [presetAppliedToast, setPresetAppliedToast] = useState<{
+    id: string;
+    message: string;
+  } | null>(null);
   const [openMap, setOpenMap] = useLocalStorage(
     'openMap',
     Array(45).fill(false) as boolean[],
@@ -373,7 +374,10 @@ const MainArea: FC = () => {
     setIsRunning(false);
     setWorkerResetCnt((prev) => prev + 1);
     const presetLabel = controlPaneT(`predefined_choice_select.${preset}`);
-    setPresetAppliedToast(t('item_preset_applied_toast', { presetLabel }));
+    setPresetAppliedToast({
+      id: crypto.randomUUID(),
+      message: t('item_preset_applied_toast', { presetLabel }),
+    });
   };
 
   const onResetMap = () => {
@@ -431,6 +435,7 @@ const MainArea: FC = () => {
         ))}
       </Grid>
       <Snackbar
+        key={presetAppliedToast?.id}
         open={presetAppliedToast !== null}
         autoHideDuration={2000}
         onClose={() => {
@@ -445,7 +450,7 @@ const MainArea: FC = () => {
             setPresetAppliedToast(null);
           }}
         >
-          {presetAppliedToast}
+          {presetAppliedToast?.message}
         </Alert>
       </Snackbar>
     </Box>

--- a/src/components/MainArea.tsx
+++ b/src/components/MainArea.tsx
@@ -1,5 +1,5 @@
 import { type FC, useState, useRef, useEffect, useCallback } from 'react';
-import { Box } from '@mui/material';
+import { Alert, Box, Snackbar } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import Grid from '@mui/material/Grid';
 import Board from './Board';
@@ -151,6 +151,7 @@ export function useLocalStorage<S>(
 const MainArea: FC = () => {
   const { t } = useTranslation('MainArea');
   const { t: errorT } = useTranslation('Error');
+  const { t: controlPaneT } = useTranslation('ControlPane');
 
   const [items, setItems] = useLocalStorage(
     'items',
@@ -160,6 +161,9 @@ const MainArea: FC = () => {
   const [isMaxProbs, setIsMaxProbs] = useState<boolean[][] | null>(null);
   const [showProbs, setShowProbs] = useState([true, true, true]);
   const [isRunning, setIsRunning] = useState(false);
+  const [presetAppliedToast, setPresetAppliedToast] = useState<string | null>(
+    null,
+  );
   const [openMap, setOpenMap] = useLocalStorage(
     'openMap',
     Array(45).fill(false) as boolean[],
@@ -368,6 +372,8 @@ const MainArea: FC = () => {
     setOpUuid(crypto.randomUUID());
     setIsRunning(false);
     setWorkerResetCnt((prev) => prev + 1);
+    const presetLabel = controlPaneT(`predefined_choice_select.${preset}`);
+    setPresetAppliedToast(t('item_preset_applied_toast', { presetLabel }));
   };
 
   const onResetMap = () => {
@@ -424,6 +430,24 @@ const MainArea: FC = () => {
           </Grid>
         ))}
       </Grid>
+      <Snackbar
+        open={presetAppliedToast !== null}
+        autoHideDuration={2000}
+        onClose={() => {
+          setPresetAppliedToast(null);
+        }}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert
+          severity="success"
+          variant="filled"
+          onClose={() => {
+            setPresetAppliedToast(null);
+          }}
+        >
+          {presetAppliedToast}
+        </Alert>
+      </Snackbar>
     </Box>
   );
 };

--- a/src/components/MainArea.tsx
+++ b/src/components/MainArea.tsx
@@ -443,15 +443,17 @@ const MainArea: FC = () => {
         }}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
       >
-        <Alert
-          severity="success"
-          variant="filled"
-          onClose={() => {
-            setPresetAppliedToast(null);
-          }}
-        >
-          {presetAppliedToast?.message}
-        </Alert>
+        {presetAppliedToast == null ? undefined : (
+          <Alert
+            severity="success"
+            variant="filled"
+            onClose={() => {
+              setPresetAppliedToast(null);
+            }}
+          >
+            {presetAppliedToast.message}
+          </Alert>
+        )}
       </Snackbar>
     </Box>
   );


### PR DESCRIPTION
## 概要

「プリセット適用後の確認ダイアログいらなくない？」という意見をもらって確かにとなったので、確認ダイアログを削除した。
ただ削除するだけだとユーザーへのフィードバックがなくて適用されたか不安になりそうだったので、代わりにユーザーの操作を邪魔しない通知を出すようにした。

## 変更内容

- プリセット適用時に表示していた確認ダイアログを削除
- プリセット適用後に Snackbar で完了通知を表示
- 通知文言は ControlPane の `predefined_choice_select` を利用
   - 例: 1周目のアイテムプリセットを適用しました / 7周目以降のアイテムプリセットを適用しました
- 多言語ロケール（ja/en/ko/zh-CN）の MainArea 文言を更新

## 動作確認

- `pnpm dev` で動作確認済み